### PR TITLE
No pointer events on tooltip.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -318,6 +318,11 @@ svg, tspan, text, div {
   cursor: pointer;
   text-decoration: underline;
 }
+
+#timeline_tooltip {
+  pointer-events: none;
+}
+
 @media screen and (max-width: 1200px) {
   /* #regionSelectContainer {
     position: absolute;


### PR DESCRIPTION
I noticed that if you quickly move the mouse on the stacked bar, the tooltip captures the pointer events and then it gets "stuck" at a particular place. This change makes it so the tooltip will not get stuck anymore.